### PR TITLE
Update exclude_strat.yml

### DIFF
--- a/.github/workflows/exclude_strat.yml
+++ b/.github/workflows/exclude_strat.yml
@@ -1,7 +1,7 @@
 name: CIFuzz
 on:
-  pull_request:
   workflow_dispatch:
+  pull_request:
 
 jobs:
   fuzzer:

--- a/.github/workflows/exclude_strat.yml
+++ b/.github/workflows/exclude_strat.yml
@@ -2,6 +2,9 @@ name: CIFuzz
 on:
   workflow_dispatch:
   pull_request:
+    types:
+      - opened
+      - edited
 
 jobs:
   fuzzer:

--- a/.github/workflows/exclude_strat.yml
+++ b/.github/workflows/exclude_strat.yml
@@ -1,7 +1,7 @@
 name: CIFuzz
 on:
-  workflow_dispatch:
   pull_request:
+  workflow_dispatch:
 
 jobs:
   fuzzer:


### PR DESCRIPTION
test with trigger pull_request 
The pull_request webhook event payload is empty for merged pull requests and pull requests that come from forked repositories.